### PR TITLE
Get tests passing on Windows

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -16,6 +16,9 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
       fail-fast: false
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: false
     defaults:
       run:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -10,10 +10,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        os: [ubuntu-latest, windows-latest]
       fail-fast: false
 
     steps:

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -1091,7 +1091,7 @@ class HTMLDependency(MetadataNode):
         href = self.name
         if include_version:
             href += "-" + str(self.version)
-        href = os.path.join(lib_prefix, href) if lib_prefix else href
+        href = lib_prefix + "/" + href if lib_prefix else href
         return {"source": source, "href": href}
 
     def as_html_tags(

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -1,5 +1,6 @@
 # pyright: reportMissingTypeStubs=false
 import os
+import posixpath
 import shutil
 import sys
 import tempfile
@@ -1092,7 +1093,7 @@ class HTMLDependency(MetadataNode):
         if include_version:
             href += "-" + str(self.version)
         if lib_prefix:
-            href = lib_prefix + "/" + href
+            href = posixpath.join(lib_prefix, href)
         return {"source": source, "href": href}
 
     def as_html_tags(
@@ -1123,7 +1124,7 @@ class HTMLDependency(MetadataNode):
             href = urllib.parse.quote(s["href"])
             s.update(
                 {
-                    "href": paths["href"] + "/" + href,
+                    "href": posixpath.join(paths["href"], href),
                     "rel": "stylesheet",
                 }
             )
@@ -1131,7 +1132,7 @@ class HTMLDependency(MetadataNode):
         scripts = deepcopy(self.script)
         for s in scripts:
             src = urllib.parse.quote(s["src"])
-            s.update({"src": paths["href"] + "/" + src})
+            s.update({"src": posixpath.join(paths["href"], src)})
 
         head: Optional[str]
         if self.head is None:

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -1091,7 +1091,8 @@ class HTMLDependency(MetadataNode):
         href = self.name
         if include_version:
             href += "-" + str(self.version)
-        href = lib_prefix + "/" + href if lib_prefix else href
+        if lib_prefix:
+            href = lib_prefix + "/" + href
         return {"source": source, "href": href}
 
     def as_html_tags(

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -1122,7 +1122,7 @@ class HTMLDependency(MetadataNode):
             href = urllib.parse.quote(s["href"])
             s.update(
                 {
-                    "href": os.path.join(paths["href"], href),
+                    "href": paths["href"] + "/" + href,
                     "rel": "stylesheet",
                 }
             )
@@ -1130,7 +1130,7 @@ class HTMLDependency(MetadataNode):
         scripts = deepcopy(self.script)
         for s in scripts:
             src = urllib.parse.quote(s["src"])
-            s.update({"src": os.path.join(paths["href"], src)})
+            s.update({"src": paths["href"] + "/" + src})
 
         head: Optional[str]
         if self.head is None:


### PR DESCRIPTION
Once tests are passing on Windows, we'll probably be able to close https://github.com/rstudio/py-shinywidgets/issues/73 (although, we should probably make sure we have appropriate dynamic UI tests running on Windows)