### PR TITLE
Add URL support to HTMLDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* Added support for URL based `HTMLDependency` objects. (#53)
+
 
 ### Bug fixes
 

--- a/htmltools/__init__.py
+++ b/htmltools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.5.9000"
+__version__ = "0.1.5.9001"
 
 from . import svg, tags
 from ._core import TagAttrArg  # pyright: ignore[reportUnusedImport]  # noqa: F401


### PR DESCRIPTION
Fixes #52

Can now add HTML Dependencies that have a source url:

```python
    b1_10 = HTMLDependency(
        "b", "1.10", source={"href": "http://b.test.com"}, script={"src": "b2.js"}
    )
```

which renders in the `<head>` to:

```python
<script src="http://b.test.com/b2.js"></script>
```

--------------

MUST set `source` to an object that contains key `"href"` with a URL location