### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: false
     defaults:

--- a/htmltools/_core.py
+++ b/htmltools/_core.py
@@ -32,15 +32,7 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Never, NotRequired, TypedDict
 
-if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol, SupportsIndex, runtime_checkable
-else:
-    from typing_extensions import (
-        SupportsIndex,
-        Protocol,
-        runtime_checkable,
-        Literal,
-    )
+from typing import Literal, Protocol, SupportsIndex, runtime_checkable
 
 from packaging.version import Version
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -30,7 +29,7 @@ project_urls =
     Source Code = https://github.com/rstudio/py-htmltools
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find:
 test_suite = tests
 include_package_data = True
@@ -48,8 +47,7 @@ test =
     pytest>=6.2.4
 dev =
     black>=23.1.0
-    flake8==5.0.4;python_version<="3.7"
-    flake8>=6.0.0;python_version>"3.7"
+    flake8>=6.0.0
     isort>=5.11.2
     pyright>=1.1.284
     pre-commit>=2.15.0


### PR DESCRIPTION
Python 3.7 has reached end of life, so this PR removes 3.7 support.